### PR TITLE
Remove README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,0 @@
-All-Github-Emoji-Icons
-======================
-
-A repo of every emoji icon as a separate file and commit.


### PR DESCRIPTION
The files list is cleaner without a README.md file. Also the content of
the file is already shown on the top of the github page (title,
description).

-- END COMMIT MESSAGE

As said here (https://github.com/scotch-io/All-Github-Emoji-Icons/issues/1#issuecomment-90571102), it would look nicer if the README.md would be removed:

Repository with README
![image](https://cloud.githubusercontent.com/assets/11049034/7025788/2f9f7926-dd46-11e4-8097-0c11640eae29.png)

Repository without README
![image](https://cloud.githubusercontent.com/assets/11049034/7025826/5ca87558-dd46-11e4-8aee-ba77db5d9ac9.png)

Keep in mind that the bottom of the page will display an info to add a README.md file. (https://github.com/robertwhitebit/All-Github-Emoji-Icons/tree/removeReadme)
`Help people interested in this repository understand your project by adding a README!`

whether you close or merge this PR, is of course completely up to you.
